### PR TITLE
スケジュールのマスをクリックすると日付と案件名が自動で選択される

### DIFF
--- a/lib/week_schedule_view.dart
+++ b/lib/week_schedule_view.dart
@@ -85,6 +85,19 @@ class _WeekScheduleViewState extends State<WeekScheduleView> {
     );
   }
 
+  void _showAddScheduleDialogForCell(DateTime date, String customer) {
+    showDialog(
+      context: context,
+      builder: (context) => ScheduleDialog(
+        title: 'スケジュールを追加',
+        initialDate: date,
+        initialCustomer: customer,
+        customers: _customers,
+        onSave: _addMultipleSchedules,
+      ),
+    );
+  }
+
   void _showEditScheduleDialog(DateTime date, String customer, String currentTitle) {
     showDialog(
       context: context,
@@ -113,7 +126,7 @@ class _WeekScheduleViewState extends State<WeekScheduleView> {
     if (schedule != null) {
       _showEditScheduleDialog(date, customer, schedule.title);
     } else {
-      _showAddScheduleDialog();
+      _showAddScheduleDialogForCell(date, customer);
     }
   }
 

--- a/lib/widgets/schedule_dialog.dart
+++ b/lib/widgets/schedule_dialog.dart
@@ -35,7 +35,7 @@ class _ScheduleDialogState extends State<ScheduleDialog> {
     super.initState();
     _titleController = TextEditingController(text: widget.initialTitle ?? '');
     _selectedCustomer = widget.initialCustomer;
-    _selectedDates = widget.initialTitle != null ? [widget.initialDate] : [];
+    _selectedDates = [widget.initialDate];
   }
 
   @override


### PR DESCRIPTION
# 概要
スケジュールのマスをクリックするとスケジュールの登録モーダルが表示されるものの、
右下と同じ内容が表示されるだけでマスに対応する日付と案件名が選択されていないので、
選択されるように修正

# 修正点
- スケジュールのマスを選択した際にスケジュール追加ダイアログを表示するメソッドを作成
- 選択した日付がスケジュール追加モーダルに反映されるように修正

# 動作確認
## 手順
### マスをクリックしてスケジュールが登録できること
- [ ] スケジュールのマスをクリックする
- [ ] クリックしたマスの左に表示している日付が選択済みになっていることを確認する
- [ ] クリックしたマスの上に表示している案件名が選択済みになっていることを確認する

# 動画

https://github.com/user-attachments/assets/b8466555-ae1e-4b62-a22c-528a0f0ec817



# 備考
バイブコーディングで作成