### PR TITLE
同じ案件の同じ日に複数のスケジュールを登録できるようにする

### DIFF
--- a/lib/week_schedule_view.dart
+++ b/lib/week_schedule_view.dart
@@ -128,62 +128,15 @@ class _WeekScheduleViewState extends State<WeekScheduleView> {
     });
   }
 
-  void _onScheduleTap(DateTime date, String customer, List<ScheduleItem>? schedules) {
-    if (schedules != null && schedules.isNotEmpty) {
-      // If there's only one schedule, edit it directly
-      if (schedules.length == 1) {
-        _showEditScheduleDialog(date, customer, schedules[0].title, 0);
-      } else {
-        // Show selection dialog for multiple schedules
-        _showScheduleSelectionDialog(date, customer, schedules);
-      }
+  void _onScheduleTap(DateTime date, String customer, int? scheduleIndex) {
+    final schedules = _schedules[date]?[customer];
+    if (schedules != null && schedules.isNotEmpty && scheduleIndex != null) {
+      _showEditScheduleDialog(date, customer, schedules[scheduleIndex].title, scheduleIndex);
     } else {
       _showAddScheduleDialogForCell(date, customer);
     }
   }
 
-  void _showScheduleSelectionDialog(DateTime date, String customer, List<ScheduleItem> schedules) {
-    showDialog(
-      context: context,
-      builder: (context) => AlertDialog(
-        title: const Text('スケジュールを選択'),
-        content: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            ...schedules.asMap().entries.map((entry) {
-              final index = entry.key;
-              final schedule = entry.value;
-              return ListTile(
-                title: Text(schedule.title),
-                trailing: IconButton(
-                  icon: const Icon(Icons.edit),
-                  onPressed: () {
-                    Navigator.of(context).pop();
-                    _showEditScheduleDialog(date, customer, schedule.title, index);
-                  },
-                ),
-              );
-            }),
-            const Divider(),
-            ListTile(
-              leading: const Icon(Icons.add),
-              title: const Text('新しいスケジュールを追加'),
-              onTap: () {
-                Navigator.of(context).pop();
-                _showAddScheduleDialogForCell(date, customer);
-              },
-            ),
-          ],
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(context).pop(),
-            child: const Text('キャンセル'),
-          ),
-        ],
-      ),
-    );
-  }
 
   @override
   Widget build(BuildContext context) {

--- a/lib/widgets/schedule_cell.dart
+++ b/lib/widgets/schedule_cell.dart
@@ -62,8 +62,8 @@ class ScheduleCell extends StatelessWidget {
                       }).toList(),
                     ),
                   ),
-                  if (schedules!.length > 1)
-                    Container(
+                  if (schedules!.isNotEmpty)
+                    SizedBox(
                       width: 20,
                       child: GestureDetector(
                         onTap: () => onScheduleTap(null),

--- a/lib/widgets/schedule_cell.dart
+++ b/lib/widgets/schedule_cell.dart
@@ -2,12 +2,12 @@ import 'package:flutter/material.dart';
 import '../week_schedule_view.dart';
 
 class ScheduleCell extends StatelessWidget {
-  final ScheduleItem? schedule;
+  final List<ScheduleItem>? schedules;
   final VoidCallback onTap;
 
   const ScheduleCell({
     super.key,
-    this.schedule,
+    this.schedules,
     required this.onTap,
   });
 
@@ -22,28 +22,40 @@ class ScheduleCell extends StatelessWidget {
               right: BorderSide(color: Colors.grey.shade300),
             ),
           ),
-          child: schedule != null
-              ? Container(
-                  height: double.infinity,
-                  padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-                  decoration: BoxDecoration(
-                    color: schedule!.isFirst 
-                        ? Colors.blue.withValues(alpha: 0.2)
-                        : Colors.grey.withValues(alpha: 0.2),
-                    borderRadius: BorderRadius.circular(4),
-                  ),
-                  child: Center(
-                    child: Text(
-                      schedule!.title,
-                      style: TextStyle(
-                        fontSize: 12,
-                        color: schedule!.isFirst ? Colors.blue[800] : Colors.grey[600],
-                        fontWeight: schedule!.isFirst ? FontWeight.bold : FontWeight.normal,
+          child: schedules != null && schedules!.isNotEmpty
+              ? Column(
+                  children: schedules!.asMap().entries.map((entry) {
+                    final index = entry.key;
+                    final schedule = entry.value;
+                    return Expanded(
+                      child: Container(
+                        width: double.infinity,
+                        padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 2),
+                        margin: EdgeInsets.only(
+                          bottom: index < schedules!.length - 1 ? 1 : 0,
+                        ),
+                        decoration: BoxDecoration(
+                          color: schedule.isFirst 
+                              ? Colors.blue.withValues(alpha: 0.2)
+                              : Colors.grey.withValues(alpha: 0.2),
+                          borderRadius: BorderRadius.circular(2),
+                        ),
+                        child: Center(
+                          child: Text(
+                            schedule.title,
+                            style: TextStyle(
+                              fontSize: schedules!.length > 1 ? 10 : 12,
+                              color: schedule.isFirst ? Colors.blue[800] : Colors.grey[600],
+                              fontWeight: schedule.isFirst ? FontWeight.bold : FontWeight.normal,
+                            ),
+                            overflow: TextOverflow.ellipsis,
+                            textAlign: TextAlign.center,
+                            maxLines: schedules!.length > 2 ? 1 : 2,
+                          ),
+                        ),
                       ),
-                      overflow: TextOverflow.ellipsis,
-                      textAlign: TextAlign.center,
-                    ),
-                  ),
+                    );
+                  }).toList(),
                 )
               : null,
         ),

--- a/lib/widgets/schedule_cell.dart
+++ b/lib/widgets/schedule_cell.dart
@@ -3,31 +3,31 @@ import '../week_schedule_view.dart';
 
 class ScheduleCell extends StatelessWidget {
   final List<ScheduleItem>? schedules;
-  final VoidCallback onTap;
+  final Function(int?) onScheduleTap;
 
   const ScheduleCell({
     super.key,
     this.schedules,
-    required this.onTap,
+    required this.onScheduleTap,
   });
 
   @override
   Widget build(BuildContext context) {
     return Expanded(
-      child: GestureDetector(
-        onTap: onTap,
-        child: Container(
-          decoration: BoxDecoration(
-            border: Border(
-              right: BorderSide(color: Colors.grey.shade300),
-            ),
+      child: Container(
+        decoration: BoxDecoration(
+          border: Border(
+            right: BorderSide(color: Colors.grey.shade300),
           ),
-          child: schedules != null && schedules!.isNotEmpty
-              ? Column(
-                  children: schedules!.asMap().entries.map((entry) {
-                    final index = entry.key;
-                    final schedule = entry.value;
-                    return Expanded(
+        ),
+        child: schedules != null && schedules!.isNotEmpty
+            ? Column(
+                children: schedules!.asMap().entries.map((entry) {
+                  final index = entry.key;
+                  final schedule = entry.value;
+                  return Expanded(
+                    child: GestureDetector(
+                      onTap: () => onScheduleTap(index),
                       child: Container(
                         width: double.infinity,
                         padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 2),
@@ -54,11 +54,17 @@ class ScheduleCell extends StatelessWidget {
                           ),
                         ),
                       ),
-                    );
-                  }).toList(),
-                )
-              : null,
-        ),
+                    ),
+                  );
+                }).toList(),
+              )
+            : GestureDetector(
+                onTap: () => onScheduleTap(null),
+                child: const SizedBox(
+                  width: double.infinity,
+                  height: double.infinity,
+                ),
+              ),
       ),
     );
   }

--- a/lib/widgets/schedule_cell.dart
+++ b/lib/widgets/schedule_cell.dart
@@ -87,9 +87,10 @@ class ScheduleCell extends StatelessWidget {
               )
             : GestureDetector(
                 onTap: () => onScheduleTap(null),
-                child: const SizedBox(
+                child: Container(
                   width: double.infinity,
                   height: double.infinity,
+                  color: Colors.transparent,
                 ),
               ),
       ),

--- a/lib/widgets/schedule_cell.dart
+++ b/lib/widgets/schedule_cell.dart
@@ -21,42 +21,69 @@ class ScheduleCell extends StatelessWidget {
           ),
         ),
         child: schedules != null && schedules!.isNotEmpty
-            ? Column(
-                children: schedules!.asMap().entries.map((entry) {
-                  final index = entry.key;
-                  final schedule = entry.value;
-                  return Expanded(
-                    child: GestureDetector(
-                      onTap: () => onScheduleTap(index),
-                      child: Container(
-                        width: double.infinity,
-                        padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 2),
-                        margin: EdgeInsets.only(
-                          bottom: index < schedules!.length - 1 ? 1 : 0,
-                        ),
-                        decoration: BoxDecoration(
-                          color: schedule.isFirst 
-                              ? Colors.blue.withValues(alpha: 0.2)
-                              : Colors.grey.withValues(alpha: 0.2),
-                          borderRadius: BorderRadius.circular(2),
-                        ),
-                        child: Center(
-                          child: Text(
-                            schedule.title,
-                            style: TextStyle(
-                              fontSize: schedules!.length > 1 ? 10 : 12,
-                              color: schedule.isFirst ? Colors.blue[800] : Colors.grey[600],
-                              fontWeight: schedule.isFirst ? FontWeight.bold : FontWeight.normal,
+            ? Row(
+                children: [
+                  Expanded(
+                    child: Column(
+                      children: schedules!.asMap().entries.map((entry) {
+                        final index = entry.key;
+                        final schedule = entry.value;
+                        return Expanded(
+                          child: GestureDetector(
+                            onTap: () => onScheduleTap(index),
+                            child: Container(
+                              width: double.infinity,
+                              padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 2),
+                              margin: EdgeInsets.only(
+                                bottom: index < schedules!.length - 1 ? 1 : 0,
+                              ),
+                              decoration: BoxDecoration(
+                                color: schedule.isFirst 
+                                    ? Colors.blue.withValues(alpha: 0.2)
+                                    : Colors.grey.withValues(alpha: 0.2),
+                                borderRadius: BorderRadius.circular(2),
+                              ),
+                              child: Center(
+                                child: Text(
+                                  schedule.title,
+                                  style: TextStyle(
+                                    fontSize: schedules!.length > 1 ? 10 : 12,
+                                    color: schedule.isFirst ? Colors.blue[800] : Colors.grey[600],
+                                    fontWeight: schedule.isFirst ? FontWeight.bold : FontWeight.normal,
+                                  ),
+                                  overflow: TextOverflow.ellipsis,
+                                  textAlign: TextAlign.center,
+                                  maxLines: schedules!.length > 2 ? 1 : 2,
+                                ),
+                              ),
                             ),
-                            overflow: TextOverflow.ellipsis,
-                            textAlign: TextAlign.center,
-                            maxLines: schedules!.length > 2 ? 1 : 2,
+                          ),
+                        );
+                      }).toList(),
+                    ),
+                  ),
+                  if (schedules!.length > 1)
+                    Container(
+                      width: 20,
+                      child: GestureDetector(
+                        onTap: () => onScheduleTap(null),
+                        child: Container(
+                          width: double.infinity,
+                          height: double.infinity,
+                          decoration: BoxDecoration(
+                            color: Colors.green.withValues(alpha: 0.3),
+                          ),
+                          child: const Center(
+                            child: Icon(
+                              Icons.add,
+                              size: 16,
+                              color: Colors.green,
+                            ),
                           ),
                         ),
                       ),
                     ),
-                  );
-                }).toList(),
+                ],
               )
             : GestureDetector(
                 onTap: () => onScheduleTap(null),

--- a/lib/widgets/schedule_dialog.dart
+++ b/lib/widgets/schedule_dialog.dart
@@ -35,7 +35,7 @@ class _ScheduleDialogState extends State<ScheduleDialog> {
     super.initState();
     _titleController = TextEditingController(text: widget.initialTitle ?? '');
     _selectedCustomer = widget.initialCustomer;
-    _selectedDates = [];
+    _selectedDates = [widget.initialDate];
   }
 
   @override

--- a/lib/widgets/schedule_dialog.dart
+++ b/lib/widgets/schedule_dialog.dart
@@ -35,7 +35,7 @@ class _ScheduleDialogState extends State<ScheduleDialog> {
     super.initState();
     _titleController = TextEditingController(text: widget.initialTitle ?? '');
     _selectedCustomer = widget.initialCustomer;
-    _selectedDates = [widget.initialDate];
+    _selectedDates = [];
   }
 
   @override
@@ -47,7 +47,7 @@ class _ScheduleDialogState extends State<ScheduleDialog> {
   Future<void> _selectDate() async {
     final DateTime? picked = await showRoundedDatePicker(
       context: context,
-      initialDate: _selectedDates.isNotEmpty ? _selectedDates.first : DateTime.now(),
+      initialDate: _selectedDates.isNotEmpty ? _selectedDates.first : widget.initialDate,
       firstDate: DateTime(2020),
       lastDate: DateTime(2030),
       locale: const Locale('ja', 'JP'),

--- a/lib/widgets/schedule_dialog.dart
+++ b/lib/widgets/schedule_dialog.dart
@@ -117,12 +117,30 @@ class _ScheduleDialogState extends State<ScheduleDialog> {
                               color: isFirst ? Colors.blue : Colors.grey,
                               borderRadius: BorderRadius.circular(12),
                             ),
-                            child: Text(
-                              '${date.month}/${date.day}',
-                              style: const TextStyle(
-                                color: Colors.white,
-                                fontSize: 12,
-                              ),
+                            child: Row(
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                Text(
+                                  '${date.month}/${date.day}',
+                                  style: const TextStyle(
+                                    color: Colors.white,
+                                    fontSize: 12,
+                                  ),
+                                ),
+                                const SizedBox(width: 4),
+                                GestureDetector(
+                                  onTap: () {
+                                    setState(() {
+                                      _selectedDates.remove(date);
+                                    });
+                                  },
+                                  child: const Icon(
+                                    Icons.close,
+                                    color: Colors.white,
+                                    size: 14,
+                                  ),
+                                ),
+                              ],
                             ),
                           );
                         }).toList(),

--- a/lib/widgets/schedule_grid.dart
+++ b/lib/widgets/schedule_grid.dart
@@ -9,7 +9,7 @@ class ScheduleGrid extends StatelessWidget {
   final DateTime selectedDay;
   final List<String> weekdays;
   final Function(DateTime) onDateTap;
-  final Function(DateTime, String, List<ScheduleItem>?) onScheduleTap;
+  final Function(DateTime, String, int?) onScheduleTap;
 
   const ScheduleGrid({
     super.key,
@@ -44,7 +44,7 @@ class ScheduleGrid extends StatelessWidget {
                 final scheduleList = schedules[date]?[customer];
                 return ScheduleCell(
                   schedules: scheduleList,
-                  onTap: () => onScheduleTap(date, customer, scheduleList),
+                  onScheduleTap: (index) => onScheduleTap(date, customer, index),
                 );
               }),
             ],

--- a/lib/widgets/schedule_grid.dart
+++ b/lib/widgets/schedule_grid.dart
@@ -5,11 +5,11 @@ import '../week_schedule_view.dart';
 class ScheduleGrid extends StatelessWidget {
   final List<DateTime> days;
   final List<String> customers;
-  final Map<DateTime, Map<String, ScheduleItem>> schedules;
+  final Map<DateTime, Map<String, List<ScheduleItem>>> schedules;
   final DateTime selectedDay;
   final List<String> weekdays;
   final Function(DateTime) onDateTap;
-  final Function(DateTime, String, ScheduleItem?) onScheduleTap;
+  final Function(DateTime, String, List<ScheduleItem>?) onScheduleTap;
 
   const ScheduleGrid({
     super.key,
@@ -41,10 +41,10 @@ class ScheduleGrid extends StatelessWidget {
             children: [
               _buildDateCell(date, isSelected),
               ...customers.map((customer) {
-                final schedule = schedules[date]?[customer];
+                final scheduleList = schedules[date]?[customer];
                 return ScheduleCell(
-                  schedule: schedule,
-                  onTap: () => onScheduleTap(date, customer, schedule),
+                  schedules: scheduleList,
+                  onTap: () => onScheduleTap(date, customer, scheduleList),
                 );
               }),
             ],


### PR DESCRIPTION
# 概要
前回までの実装では同じ案件の同じ日に１つしかスケジュールを入れることができなかったので、
３件まで登録できるように修正
選択した日付をバツアイコンで削除できるように対応

# 修正点
- 1日に登録できるスケジュールを３件までに修正
- スケジュール登録モーダルで指定した日付をバツアイコンで削除できるように修正

# 動作確認
## 手順
### 同じ日と同じ案件に３件まで予定が登録できること
- [ ] 予定を追加したい日付と案件名に重なるマスをクリックする
- [ ] タイトルを適当につけて追加ボタンをクリック
- [ ] クリックしたマスに先ほどの予定が追加されており、予定の右に追加ボタンが表示されていることを確認する
- [ ] 追加ボタンをクリックして1つ目の予定と同じように追加する
- [ ] マスの中に追加した２つの予定が上下に並んでいることを確認する
- [ ] さらに追加ボタンをクリックして予定を追加する
- [ ] マスの中に追加した３件の予定が上下に並んでいることを確認する

### 追加した日付がバツアイコンで削除できる
- [ ] 適当なマスをクリックする
- [ ] クリックしたマスの日付が指定されているので、日付の右に表示されているバツアイコンをクリックして日付の選択が解除できることを確認する

# 動画


https://github.com/user-attachments/assets/0fe72796-03de-4876-bd40-d52dd308cebf



# 備考
バイブコーディングで作成