### PR TITLE
1つのマスに予定が３つあるときは追加ボタンを表示しない

### DIFF
--- a/lib/widgets/schedule_cell.dart
+++ b/lib/widgets/schedule_cell.dart
@@ -62,7 +62,7 @@ class ScheduleCell extends StatelessWidget {
                       }).toList(),
                     ),
                   ),
-                  if (schedules!.isNotEmpty)
+                  if (schedules!.isNotEmpty && schedules!.length < 3)
                     SizedBox(
                       width: 20,
                       child: GestureDetector(


### PR DESCRIPTION
# 概要
1つのマスに登録できるのが３つまでなので、
３つスケジュールが登録されている場合は追加ボタンを表示しない

# 修正点
- スケジールが３つ登録されているマスには追加ボタンを表示しない

# 動作確認
## 手順
###  1つのマスに３つ予定が登録されると追加ボタンを表示しない
- [ ] 同じマスに３つ予定を追加する
- [ ] 1〜２つまでは追加ボタンが表示され、３つ目になると追加ボタンが削除されることを確認する


# 動画

https://github.com/user-attachments/assets/b35bd145-d79d-4513-9d56-482c68acc6d6





# 備考
バイブコーディングで作成